### PR TITLE
concurrent doesn't return double promise type

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -109,7 +109,7 @@ export type Callback< R, A extends any[ ] > =
 export function concurrent< R, A extends any[ ] >(
 	size: number,
 	fn: Callback< R, A >
-): ( ...args: Parameters< typeof fn > ) => Promise< ReturnType< typeof fn > >;
+): ( ...a: A ) => Promise< R >;
 
 export function concurrent( size: number )
 : < R, A extends any[ ] >( fn: Callback< R, A >, ...a: A ) => Promise< R >;


### PR DESCRIPTION
simplify type definition concurrent (callback mode)
make sure concurrent (callback mode) doesn't return `Promise<Promise<x>>`