### PR TITLE
Improve types of props

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -208,8 +208,8 @@ export function tap<
 	};
 }
 
-
-export function props( obj: any ): Promise< any >
+type PromiseResult<V> = V extends PromiseLike<infer R> ? R : V;
+export function props<O extends Record<string, any>>( obj: O ): Promise< {[key in keyof O]: PromiseResult<O[key]>} >
 {
 	const ret: any = { };
 


### PR DESCRIPTION
This PR improves the return type of the `props` function

```ts
const val = await props( { a: 1, b: delay( 10 ).then( ( ) => 2 ) } );
// Before: any
// After: { a: number; b: number; }
```